### PR TITLE
[Joaquina-7] Adiciona Testes para os botões da Navbar

### DIFF
--- a/src/components/molecules/Navbar.spec.jsx
+++ b/src/components/molecules/Navbar.spec.jsx
@@ -1,15 +1,56 @@
-import { BrowserRouter } from "react-router-dom"
+import { Await, BrowserRouter } from "react-router-dom"
 import { render, screen } from "@testing-library/react";
 import Navbar from "./Navbar";
+import userEvent from '@testing-library/user-event'
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useNavigate: () => mockNavigate,
+}));
+
+
+const user = userEvent.setup()
+
+function renderComponent() {
+    render(
+        <BrowserRouter>
+            <Navbar />
+        </BrowserRouter>)
+}
 
 describe("Navbar", () => {
-    it("deveria ter um titulo DevInHouse - Navbar", () => {
-        render(
-            <BrowserRouter>
-                <Navbar />
-            </BrowserRouter>)
 
+    it("deveria ter um botão para a página Dashboard",() => {
+        renderComponent()
+        const buttonDashboard = screen.getByRole("button", { name: /Dashboard/i });
+        expect(buttonDashboard).toBeInTheDocument();
+        
+    })
+
+
+    it("deveria ter um titulo DevInHouse - Navbar", () => {
+        renderComponent()
         const titulo = screen.getByText("DevInHouse - Navbar");
         expect(titulo).toBeInTheDocument();
+
+
+
     })
+
+    it("deveria redirecionar para a página dashboard quando clica no botão dashboard",async() => {
+        renderComponent()
+        const buttonDashboard = screen.getByRole("button", { name: /Dashboard/i });
+
+        await user.click(buttonDashboard)
+
+        expect(mockNavigate).toHaveBeenCalledWith("/")
+        
+
+    })
+
+
+
+
+        
 })

--- a/src/components/molecules/Navbar.spec.jsx
+++ b/src/components/molecules/Navbar.spec.jsx
@@ -1,4 +1,4 @@
-import { Await, BrowserRouter } from "react-router-dom"
+import { BrowserRouter } from "react-router-dom"
 import { render, screen } from "@testing-library/react";
 import Navbar from "./Navbar";
 import userEvent from '@testing-library/user-event'
@@ -8,7 +8,6 @@ jest.mock("react-router-dom", () => ({
     ...jest.requireActual("react-router-dom"),
     useNavigate: () => mockNavigate,
 }));
-
 
 const user = userEvent.setup()
 
@@ -25,7 +24,6 @@ describe("Navbar", () => {
         renderComponent()
         const buttonDashboard = screen.getByRole("button", { name: /Dashboard/i });
         expect(buttonDashboard).toBeInTheDocument();
-        
     })
 
 
@@ -33,9 +31,6 @@ describe("Navbar", () => {
         renderComponent()
         const titulo = screen.getByText("DevInHouse - Navbar");
         expect(titulo).toBeInTheDocument();
-
-
-
     })
 
     it("deveria redirecionar para a página dashboard quando clica no botão dashboard",async() => {
@@ -45,8 +40,15 @@ describe("Navbar", () => {
         await user.click(buttonDashboard)
 
         expect(mockNavigate).toHaveBeenCalledWith("/")
-        
+    })
 
+    it("deveria redirecionar para a página unidades quando clica no botão Unidade Consumidora",async() => {
+        renderComponent()
+        const botaoUnidadeConsumidora = screen.getByRole("button", { name: /Unidade Consumidora/i });
+
+        await user.click(botaoUnidadeConsumidora)
+
+        expect(mockNavigate).toHaveBeenCalledWith("/unidades")
     })
 
 

--- a/src/pages/Unidades/Unidades.spec.jsx
+++ b/src/pages/Unidades/Unidades.spec.jsx
@@ -1,0 +1,11 @@
+import { BrowserRouter } from "react-router-dom"
+import { render, screen } from "@testing-library/react";
+import Unidades from "./Unidades"
+
+function renderComponent(){
+    render(
+    <BrowserRouter>
+        <Unidades />
+    </BrowserRouter>
+    )
+}


### PR DESCRIPTION
# O que mudou?

Foram adicionados testes para os botões "Dashboard" e "Unidade Consumidora" no componente Navbar.

# Como testar?

Rode o comando `npm run test src/components/molecules/Navbar.spec.jsx` e todos os testes devem ter passado.

![image](https://github.com/FuturoDEV-Joaquina/solarenergy-time-a-1/assets/45580434/db62cd5a-8a5a-475f-a052-7b79ac46f8e3)
